### PR TITLE
AutoCommandBindings does not correctly bind if the VM method ends with "Command"

### DIFF
--- a/src/net35/Radical.Windows/Presentation/CommandBuilders/CommandData.cs
+++ b/src/net35/Radical.Windows/Presentation/CommandBuilders/CommandData.cs
@@ -10,6 +10,8 @@ namespace Topics.Radical.Windows.CommandBuilders
 {
     public class CommandData
     {
+        public string MethodName;
+
         public Object DataContext;
         public LateBoundVoidMethod FastDelegate;
 

--- a/src/net40/Test.Radical.Windows/DelegateCommandBuilderTests.cs
+++ b/src/net40/Test.Radical.Windows/DelegateCommandBuilderTests.cs
@@ -18,18 +18,28 @@ namespace Test.Radical.Windows
                 this.MyProperty = new NestedPropertyClass();
             }
 
+            public NestedPropertyClass MyProperty { get; private set; }
+
             public void DoSomething() { }
+
+            public void DoSomethingCommand() { }
 
             public void EndsWithCommand() { }
 
-            public NestedPropertyClass MyProperty { get; set; }
+            public void EndsWithcommand(){}
+
+            public void WithoutCommandSuffix() { }
         }
 
         class NestedPropertyClass 
         {
-            public void DoSomethingElse() { }
+            public void DoSomethingElse(){}
 
-            public void OtherThatEndsWithCommand() { }
+            public void DoSomethingElseCommand(){}
+
+            public void OtherThatEndsWithCommand(){}
+
+            public void OtherThatEndsWithcommand(){}
         }
 
         [TestMethod]
@@ -46,6 +56,51 @@ namespace Test.Radical.Windows
         }
 
         [TestMethod]
+        [TestCategory("DelegateCommandBuilder")]
+        public void DelegateCommandBuilder_using_simple_method_with_Command_suffix_should_generate_CommandData()
+        {
+            var sut = new DelegateCommandBuilder();
+
+            CommandData cd;
+            var succeeded = sut.TryGenerateCommandData(new PropertyPath("DoSomethingCommand"), new TestDataContext(), out cd);
+
+            Assert.IsTrue(succeeded);
+            Assert.IsTrue(cd.FastDelegate != null);
+        }
+
+        [TestMethod]
+        [TestCategory("DelegateCommandBuilder")]
+        public void DelegateCommandBuilder_using_simple_method_with_no_Command_suffix_should_generate_CommandData_with_exact_match()
+        {
+            var sut = new DelegateCommandBuilder();
+            var dc = new TestDataContext();
+            var methodToInvoke = "DoSomething";
+
+            CommandData cd;
+            var succeeded = sut.TryGenerateCommandData(new PropertyPath(methodToInvoke), dc, out cd);
+
+            cd.FastDelegate(dc, null);
+
+            Assert.AreEqual(methodToInvoke, cd.MethodName);
+        }
+
+        [TestMethod]
+        [TestCategory("DelegateCommandBuilder")]
+        public void DelegateCommandBuilder_using_simple_method_with_Command_suffix_should_generate_CommandData_with_exact_match()
+        {
+            var sut = new DelegateCommandBuilder();
+            var dc = new TestDataContext();
+            var methodToInvoke = "DoSomethingCommand";
+
+            CommandData cd;
+            var succeeded = sut.TryGenerateCommandData(new PropertyPath(methodToInvoke), dc, out cd);
+
+            cd.FastDelegate(dc, null);
+
+            Assert.AreEqual(methodToInvoke, cd.MethodName);
+        }
+
+        [TestMethod]
         [TestCategory( "DelegateCommandBuilder" )]
         public void DelegateCommandBuilder_using_simple_method_on_nested_property_should_generate_CommandData()
         {
@@ -56,6 +111,19 @@ namespace Test.Radical.Windows
 
             Assert.IsTrue( succeeded );
             Assert.IsTrue( cd.FastDelegate != null );
+        }
+
+        [TestMethod]
+        [TestCategory("DelegateCommandBuilder")]
+        public void DelegateCommandBuilder_using_simple_method_on_nested_property_Command_suffix_should_generate_CommandData()
+        {
+            var sut = new DelegateCommandBuilder();
+
+            CommandData cd;
+            var succeeded = sut.TryGenerateCommandData(new PropertyPath("MyProperty.DoSomethingElseCommand"), new TestDataContext(), out cd);
+
+            Assert.IsTrue(succeeded);
+            Assert.IsTrue(cd.FastDelegate != null);
         }
 
         [TestMethod]
@@ -99,7 +167,6 @@ namespace Test.Radical.Windows
 
         [TestMethod]
         [TestCategory( "DelegateCommandBuilder" )]
-        [Ignore] // temporary ignore to test the build server
         public void DelegateCommandBuilder_using_PropertyPath_that_ends_with_Command_should_succeed()
         {
             var sut = new DelegateCommandBuilder();
@@ -113,7 +180,6 @@ namespace Test.Radical.Windows
 
         [TestMethod]
         [TestCategory( "DelegateCommandBuilder" )]
-        [Ignore] // temporary ignore to test the build server
         public void DelegateCommandBuilder_using_nested_PropertyPath_that_ends_with_Command_should_succeed()
         {
             var sut = new DelegateCommandBuilder();
@@ -123,6 +189,46 @@ namespace Test.Radical.Windows
 
             Assert.IsTrue( succeeded );
             Assert.IsTrue( cd.FastDelegate != null );
+        }
+
+        [TestMethod]
+        [TestCategory("DelegateCommandBuilder")]
+        public void DelegateCommandBuilder_using_PropertyPath_that_ends_with_command_lowercase_should_succeed()
+        {
+            var sut = new DelegateCommandBuilder();
+
+            CommandData cd;
+            var succeeded = sut.TryGenerateCommandData(new PropertyPath("EndsWithcommand"), new TestDataContext(), out cd);
+
+            Assert.IsTrue(succeeded);
+            Assert.IsTrue(cd.FastDelegate != null);
+        }
+
+        [TestMethod]
+        [TestCategory("DelegateCommandBuilder")]
+        public void DelegateCommandBuilder_using_nested_PropertyPath_that_ends_with_command_lowercase_should_succeed()
+        {
+            var sut = new DelegateCommandBuilder();
+
+            CommandData cd;
+            var succeeded = sut.TryGenerateCommandData(new PropertyPath("MyProperty.OtherThatEndsWithcommand"), new TestDataContext(), out cd);
+
+            Assert.IsTrue(succeeded);
+            Assert.IsTrue(cd.FastDelegate != null);
+        }
+
+        [TestMethod]
+        [TestCategory("DelegateCommandBuilder")]
+        public void DelegateCommandBuilder_using_PropertyPath_that_ends_with_Command_but_method_doesnt_should_succeed()
+        {
+            //this is for backward compatibility
+            var sut = new DelegateCommandBuilder();
+
+            CommandData cd;
+            var succeeded = sut.TryGenerateCommandData(new PropertyPath("WithoutCommandSuffixCommand"), new TestDataContext(), out cd);
+
+            Assert.IsTrue(succeeded);
+            Assert.IsTrue(cd.FastDelegate != null);
         }
     }
 }


### PR DESCRIPTION
I finally found the time to have a look at this long time bug. The actual fix is designed to be backward compatible with 1.6.0, thus I'm proposing to release it as a hotfix against `master`. Once released we can backport it to `develop`.

@micdenny please review.

Connects to #3 
Fix #3